### PR TITLE
Reduce need to use upstream debian + pip cache

### DIFF
--- a/12.0.2/Dockerfile_3.10
+++ b/12.0.2/Dockerfile_3.10
@@ -6,7 +6,8 @@ LABEL vendor="Gurobi"
 LABEL version=${GRB_VERSION}
 
 # update system and certificates
-# RUN sed -i 's|http://deb.debian.org|http://ftp.de.debian.org|g' /etc/apt/sources.list \
+RUN sed -i 's|http://deb.debian.org|https://nexus.compute.gurobi.com/repository/debian|g' /etc/apt/sources.list.d/debian.sources
+RUN printf "[global]\nindex = https://nexus.compute.gurobi.com/repository/pypi-proxy/pypi\nindex-url = https://nexus.compute.gurobi.com/repository/pypi-proxy/simple" > /etc/pip.conf
 RUN apt-get update \
     && apt-get install --no-install-recommends -y\
        ca-certificates  \

--- a/12.0.2/Dockerfile_3.11
+++ b/12.0.2/Dockerfile_3.11
@@ -6,6 +6,8 @@ LABEL vendor="Gurobi"
 LABEL version=${GRB_VERSION}
 
 # update system and certificates
+RUN sed -i 's|http://deb.debian.org|https://nexus.compute.gurobi.com/repository/debian|g' /etc/apt/sources.list.d/debian.sources
+RUN printf "[global]\nindex = https://nexus.compute.gurobi.com/repository/pypi-proxy/pypi\nindex-url = https://nexus.compute.gurobi.com/repository/pypi-proxy/simple" > /etc/pip.conf
 RUN apt-get update \
     && apt-get install --no-install-recommends -y\
        ca-certificates  \

--- a/12.0.2/Dockerfile_3.12
+++ b/12.0.2/Dockerfile_3.12
@@ -6,6 +6,8 @@ LABEL vendor="Gurobi"
 LABEL version=${GRB_VERSION}
 
 # update system and certificates
+RUN sed -i 's|http://deb.debian.org|https://nexus.compute.gurobi.com/repository/debian|g' /etc/apt/sources.list.d/debian.sources
+RUN printf "[global]\nindex = https://nexus.compute.gurobi.com/repository/pypi-proxy/pypi\nindex-url = https://nexus.compute.gurobi.com/repository/pypi-proxy/simple" > /etc/pip.conf
 RUN apt-get update \
     && apt-get install --no-install-recommends -y\
        ca-certificates  \

--- a/12.0.2/Dockerfile_3.9
+++ b/12.0.2/Dockerfile_3.9
@@ -6,7 +6,8 @@ LABEL vendor="Gurobi"
 LABEL version=${GRB_VERSION}
 
 # update system and certificates
-# RUN sed -i 's|http://deb.debian.org|http://ftp.de.debian.org|g' /etc/apt/sources.list \
+RUN sed -i 's|http://deb.debian.org|https://nexus.compute.gurobi.com/repository/debian|g' /etc/apt/sources.list.d/debian.sources
+RUN printf "[global]\nindex = https://nexus.compute.gurobi.com/repository/pypi-proxy/pypi\nindex-url = https://nexus.compute.gurobi.com/repository/pypi-proxy/simple" > /etc/pip.conf
 RUN apt-get update \
     && apt-get install --no-install-recommends -y\
        ca-certificates  \


### PR DESCRIPTION
@walegurobi regarding our discussion together with Thomas and Brian: I implemened he usage of nexus3 as cache for dockerbuilds into your Dockerfiles as an example. I think this is much easier to understand than writing long texts in teams.

* `sed` in the correct source list - beginning with bookworm, debian don't use the /etc/apt/sources.list anymore (same for ubuntu24.04)
* Create a PyPI configuration that retrieves packages from the Nexus repository instead directly from upstream.

To side effects:

* faster - a package is only downloaded from upstream once. Next builds are around 3 times faster for this small Dockerfile
* No risk to get blocked from debian proxy anymore

hope this helps.